### PR TITLE
user_nameの追加による変更修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
     with_options format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'は英数字混合で入力してください' } do
       validates :password
-      validates :user_name, uniqueness: true
+      validates :user_name, uniqueness: { case_sensitive: true }
     end
   end
   

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user do
     nickname              {Faker::Name.initials(number: 2)}
+    user_name             {"Name123"}
     email                 {Faker::Internet.free_email}
     password              {Faker::Internet.password(min_length: 6)}
     password_confirmation {password}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,7 +5,7 @@ describe User do
   end
   describe 'ユーザー新規登録' do
     context '新規登録がうまくいくとき' do
-      it 'nicknameとemail、passwordとpassword_confirmationが存在すれば登録できる' do
+      it 'nicknameとuser_name、email、passwordとpassword_confirmationが存在すれば登録できる' do
         expect(@user).to be_valid
       end
       it 'passwordが英数字混合で6文字以上で登録できる' do
@@ -20,6 +20,21 @@ describe User do
         @user.nickname = ''
         @user.valid?
         expect(@user.errors.full_messages).to include('ニックネームを入力してください')
+      end
+      it 'user_nameが空だと登録できない' do
+        @user.user_name = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include('ユーザーidを入力してください')
+      end
+      it 'user_nameがアルファベットだけだと登録できない' do
+        @user.user_name = 'Name'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('ユーザーidは英数字混合で入力してください')
+      end
+      it 'user_nameが数字だけだと登録できない' do
+        @user.user_name = '123'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('ユーザーidは英数字混合で入力してください')
       end
       it 'emailが空だと登録できない' do
         @user.email = ''


### PR DESCRIPTION
#what
user_nameの修正
#why
user_nameの一意性での警告文対策。
user_nameの単体テストコードを追加。