### PR TITLE
チーム詳細表示機能

### DIFF
--- a/app/assets/stylesheets/teams/show.css
+++ b/app/assets/stylesheets/teams/show.css
@@ -1,0 +1,37 @@
+.team-wrap{
+  padding: 8px 19px;
+  margin: 2em 30%;
+  color: #2c2c2f;
+  border-top: solid 5px #5989cf;
+  border-bottom: solid 5px #5989cf;
+}
+
+.team-action{
+  text-align: center;
+}
+.action-btn{
+  list-style: none;
+  width: 100%;
+  margin-top: 50px;
+}
+.team-edit-btn{
+  text-decoration: none;
+  background-color: skyblue;
+  font-size: 20px;
+  font-weight: bold;
+  color: #FFF;
+  margin: 20px 0px;
+  padding: 2vh 3vw;
+}
+.or-text{
+  font-size: 20px;
+}
+.team-destroy{
+  text-decoration: none;
+  background-color: skyblue;
+  text-align: center;
+  font-size: 20px;
+  color: #FFF;
+  margin: 20px 0px;
+  padding: 2vh 5vw;
+}

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -17,6 +17,10 @@ class TeamsController < ApplicationController
     end
   end
 
+  def show
+    @team = Team.find(params[:id])
+  end
+
   private
   def team_params
     params.require(:team).permit(:team_name, user_ids:[])

--- a/app/views/shared/_list.html.erb
+++ b/app/views/shared/_list.html.erb
@@ -3,6 +3,9 @@
     <%= link_to '新規リスト作成', new_team_list_path, class:"lists-create" %>
   </div>
   <div class="lists">
+    <div class="team-info">
+      <%= @team.team_name %>
+    </div>
     <% @lists.each do |list| %>
     <div class="list">
       <div class="list-name">

--- a/app/views/shared/_list.html.erb
+++ b/app/views/shared/_list.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="lists">
     <div class="team-info">
-      <%= @team.team_name %>
+      <%= link_to @team.team_name, team_path(@team.id), class:"team-text" %>
     </div>
     <% @lists.each do |list| %>
     <div class="list">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,0 +1,20 @@
+<%= render 'shared/header' %>
+
+<div class="team-wrap">
+  <div class="team-name">
+    <%= @team.team_name %>
+  </div>
+  <div class:"team-member">
+    チームメンバー<br>
+    <% @team.users.each do |user| %>
+      <%= user.nickname %>
+    <% end %>
+  </div>
+  <div class="team-action">
+    <div class="action-btn">
+      <%= link_to 'チームの編集', "#", method: :get, class: "team-edit-btn" %>
+      <p class='or-text'>OR</p>
+      <%= link_to '削除', "#", method: :delete, class:'team-destroy' %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "teams#index"
-  resources :teams, only: [:new, :create] do
+  resources :teams, only: [:new, :create, :show] do
     resources :lists, only: [:index, :new, :create]
   end
 end


### PR DESCRIPTION
#what
チーム詳細ページを実装
#why
トップページはすっきりまとめたいため、チームの情報を見れるページが欲しい。
また、編集機能やチーム削除機能を載せるため。